### PR TITLE
修复本科生订阅失效：适配新版 SSO 加密

### DIFF
--- a/DL444.CquSchedule.Backend/Services/ScheduleService.cs
+++ b/DL444.CquSchedule.Backend/Services/ScheduleService.cs
@@ -115,8 +115,15 @@ namespace DL444.CquSchedule.Backend.Services
 
             request = new HttpRequestMessage(HttpMethod.Get, "https://my.cqu.edu.cn/authserver/oauth/authorize?client_id=enroll-prod&response_type=code&scope=all&state=&redirect_uri=https%3A%2F%2Fmy.cqu.edu.cn%2Fenroll%2Ftoken-index");
             response = await httpClient.SendRequestFollowingRedirectsAsync(request, cookieContainer);
-            Regex regex = new Regex("code=(.{6})");
-            string code = regex.Match(response.RequestMessage.RequestUri.ToString()).Groups[1].Value;
+            string code = GetQueryParameter(response.RequestMessage?.RequestUri, "code");
+            if (string.IsNullOrEmpty(code))
+            {
+                AuthenticationException authEx = new AuthenticationException("Failed to authenticate user. Server did not return a valid authorization code.")
+                {
+                    Result = AuthenticationResult.UnknownFailure,
+                };
+                throw authEx;
+            }
 
             request = new HttpRequestMessage(HttpMethod.Post, "https://my.cqu.edu.cn/authserver/oauth/token");
             request.Content = new FormUrlEncodedContent(new[]
@@ -129,8 +136,8 @@ namespace DL444.CquSchedule.Backend.Services
             });
             response = await httpClient.SendRequestFollowingRedirectsAsync(request, cookieContainer);
 
-            regex = new Regex("\"access_token\":\"(.*?)\"");
-            Match tokenMatch = regex.Match(await response.Content.ReadAsStringAsync());
+            Regex tokenRegex = new Regex("\"access_token\":\"(.*?)\"");
+            Match tokenMatch = tokenRegex.Match(await response.Content.ReadAsStringAsync());
             if (!tokenMatch.Success)
             {
                 AuthenticationException authEx = new AuthenticationException("Failed to authenticate user. Server did not return a token.")
@@ -360,6 +367,28 @@ namespace DL444.CquSchedule.Backend.Services
                 hint = 1;
             }
             return (hint, term);
+        }
+
+        private static string GetQueryParameter(Uri uri, string key)
+        {
+            if (uri == null || string.IsNullOrEmpty(uri.Query) || string.IsNullOrEmpty(key))
+            {
+                return null;
+            }
+            string query = uri.Query[1..];
+            foreach (var part in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+            {
+                int separator = part.IndexOf('=');
+                if (separator < 0)
+                {
+                    continue;
+                }
+                if (part[..separator].Equals(key, StringComparison.Ordinal))
+                {
+                    return Uri.UnescapeDataString(part[(separator + 1)..]);
+                }
+            }
+            return null;
         }
 
         private static SigninInfo GetSigninInfo(string html)

--- a/DL444.CquSchedule.Backend/Services/UpstreamCredentialEncryptionService.cs
+++ b/DL444.CquSchedule.Backend/Services/UpstreamCredentialEncryptionService.cs
@@ -11,14 +11,32 @@ namespace DL444.CquSchedule.Backend.Services
 
     internal sealed class UpstreamCredentialEncryptionService : IUpstreamCredentialEncryptionService
     {
-        public string Encrypt(string password, string key) => GetDesString(password, key);
+        public string Encrypt(string password, string key)
+        {
+            byte[] keyBytes = Convert.FromBase64String(key);
+            return keyBytes.Length switch
+            {
+                8 => EncryptDes(password, keyBytes),
+                16 or 24 or 32 => EncryptAes(password, keyBytes),
+                _ => throw new CryptographicException($"Upstream credential key size is unsupported: {keyBytes.Length} bytes.")
+            };
+        }
 
-        private static string GetDesString(string data, string key)
+        private static string EncryptDes(string data, byte[] keyBytes)
         {
             byte[] plaintext = new UTF8Encoding(false, true).GetBytes(data);
             using var des = DES.Create();
-            des.Key = Convert.FromBase64String(key);
+            des.Key = keyBytes;
             byte[] encrypted = des.EncryptEcb(plaintext, PaddingMode.PKCS7);
+            return Convert.ToBase64String(encrypted);
+        }
+
+        private static string EncryptAes(string data, byte[] keyBytes)
+        {
+            byte[] plaintext = new UTF8Encoding(false, true).GetBytes(data);
+            using var aes = Aes.Create();
+            aes.Key = keyBytes;
+            byte[] encrypted = aes.EncryptEcb(plaintext, PaddingMode.PKCS7);
             return Convert.ToBase64String(encrypted);
         }
     }


### PR DESCRIPTION
Fixes #17 

# 背景
1 月教务登录机制调整后，本科生创建订阅接口会失败。
研究生端（MIS）线上目前仍正常。

# 修改内容
## 加密部分

  原逻辑只支持 DES（8 字节 key）
  现改为按 key 长度自动选择：
  8 字节：DES（保持兼容）
  16/24/32 字节：AES
  其他长度：抛出明确异常

## OAuth code
  OAuth code 解析不再写死 6 位正则
  改为从回调 URL 的 query 中读取 code
  code 缺失时抛出明确认证异常

# 本地测试通过
<img width="955" height="706" alt="2622e0aa079a9e1fb80c3e77029cd5ba" src="https://github.com/user-attachments/assets/aa0a7a69-f39e-49bf-90b4-6975b03e0a89" />